### PR TITLE
Use Dispatcher to register MainWindow OnClosed event handler

### DIFF
--- a/Gu.Wpf.NumericInput/Touch/TextBox.cs
+++ b/Gu.Wpf.NumericInput/Touch/TextBox.cs
@@ -29,11 +29,14 @@ namespace Gu.Wpf.NumericInput.Touch
                 typeof(System.Windows.Controls.TextBox),
                 UIElement.LostFocusEvent,
                 new RoutedEventHandler(OnLostFocus));
-            var mainWindow = Application.Current?.MainWindow;
-            if (mainWindow != null)
+            Application.Current.Dispatcher.Invoke(() =>
             {
-                mainWindow.Closed += OnClosed;
-            }
+                var mainWindow = Application.Current?.MainWindow;
+                if (mainWindow != null)
+                {
+                    mainWindow.Closed += OnClosed;
+                }
+            });
         }
 
         /// <summary>Helper for setting <see cref="ShowTouchKeyboardOnTouchEnterProperty"/> on <paramref name="element"/>.</summary>


### PR DESCRIPTION
Fixes WPF designer crashes when trying to expand the Miscellaneous properties.

Using debugger, we can learn that "Application.Current?.MainWindow" throws an exception as the calling thread cannot access MainWindow, because a different thread owns it.


This doesn't make the touch section work completely again, but at least the designer in recent versions of Visual Studio (2022, 17.10) doesn't crash right away.